### PR TITLE
fix: update workflows to use CARGO_REGISTRY_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check if package is publishable
         run: cargo publish --dry-run
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           
       - name: Verify version matches tag
         run: |
@@ -86,7 +86,7 @@ jobs:
           command: cargo publish
           on_retry_command: cargo update && sleep 30
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           
       - name: Verify package on crates.io
         run: |

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           # Fix up the .releaserc.json to avoid shell expansion issues
           sed -i 's/\$\${nextRelease\.version}/\${nextRelease.version}/g' .releaserc.json


### PR DESCRIPTION
- Change environment variable references from CRATES_TOKEN to CARGO_REGISTRY_TOKEN
- Use consistent naming across all GitHub workflows